### PR TITLE
[FIXED] SHLVL start

### DIFF
--- a/src/envp_utils.c
+++ b/src/envp_utils.c
@@ -5,10 +5,16 @@ char	**mod_envp_shlvl(char **envp)
 	int		i;
 	int		nb;
 	char	*aux;
+	char	*shlvl;
 
 	i = search_envp(envp, "SHLVL");
 	if (i == -1)
-		return (NULL);
+	{
+		shlvl = ft_strjoin("SHLVL=", "1");
+		if (!shlvl)
+			exit_malloc();
+		return (insert_envp(envp, shlvl));
+	}
 	nb = ft_atoi(&envp[i][6]);
 	free(envp[i]);
 	nb += 1;

--- a/src/parser/init.c
+++ b/src/parser/init.c
@@ -34,7 +34,7 @@ static char	**small_envp(void)
 	char	*path;
 	char	**new_env;
 
-	new_env = malloc(4 * sizeof(char *));
+	new_env = ft_calloc(3, sizeof(char *));
 	if (!new_env)
 		exit_malloc();
 	path = getcwd(NULL, 0);
@@ -42,9 +42,6 @@ static char	**small_envp(void)
 	free(path);
 	if (!new_env[0])
 		return (clean_env(new_env, 0));
-	new_env[1] = ft_strdup("SHLVL=1");
-	if (!new_env[1])
-		return (clean_env(new_env, 1));
 	new_env[2] = ft_strdup("_=/usr/bin/env");
 	if (!new_env[2])
 		return (clean_env(new_env, 2));


### PR DESCRIPTION
If the SHLVL is not declared at the start of the execution, it is created correctly with value 1